### PR TITLE
make fluidsynth sampling_rate float

### DIFF
--- a/robopianist/music/midi_file.py
+++ b/robopianist/music/midi_file.py
@@ -231,7 +231,7 @@ class MidiFile:
     def synthesize(self, sampling_rate: int = consts.SAMPLING_RATE) -> np.ndarray:
         """Synthesize the MIDI file into a waveform using FluidSynth."""
         return midi_synth.fluidsynth(
-            self.seq, sample_rate=sampling_rate, sf2_path=str(SF2_PATH)
+            self.seq, sample_rate=float(sampling_rate), sf2_path=str(SF2_PATH)
         )
 
     def play(self, sampling_rate: int = consts.SAMPLING_RATE) -> None:


### PR DESCRIPTION
When running midi playback, `python examples/play_midi_file.py --file robopianist/music/data/rousseau/twinkle-twinkle-trimmed.mid`, we get this warning from fluidsynth.
<img width="1566" alt="Screen Shot 2023-04-03 at 10 32 42 PM" src="https://user-images.githubusercontent.com/13341926/229673041-00df017a-a056-4e49-b83b-da1831df168f.png">

Referring to https://github.com/nwhitehead/pyfluidsynth/issues/37, we can fix this by making sure the `samplerate`  argument to the `fluidsynth(...)` call is a float.

Now there are no more warnings. All tests pass.